### PR TITLE
feat: add Google review generation system (Route 1 + Route 2)

### DIFF
--- a/app/internal/review-links/layout.tsx
+++ b/app/internal/review-links/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Review Links — Internal Staff Tool | Mountain Spine & Orthopedics",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function InternalLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/internal/review-links/page.tsx
+++ b/app/internal/review-links/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { getReviewLocations } from "@/lib/reviewLinks";
+
+export default function ReviewLinksPage() {
+  const locations = getReviewLocations();
+  const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
+
+  const handleCopy = async (locationSlug: string, url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedStates(prev => ({ ...prev, [locationSlug]: true }));
+      setTimeout(() => {
+        setCopiedStates(prev => ({ ...prev, [locationSlug]: false }));
+      }, 2000);
+    } catch {
+      // clipboard API unavailable — fail silently
+    }
+  };
+
+  return (
+    <div
+      className="bg-gray-50 min-h-screen py-12 px-4"
+      style={{ fontFamily: "var(--font-inter)" }}
+    >
+      <div className="max-w-3xl mx-auto space-y-8">
+        {/* Header */}
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold text-[#252932]">Google Review Links</h1>
+          <p className="text-gray-500">
+            Send the correct link to patients after their clinic is assigned by phone.
+          </p>
+          <div className="bg-blue-50 border border-blue-100 rounded-lg p-4 text-sm text-gray-600 leading-relaxed">
+            After a patient's clinic is confirmed by phone, copy the link for that location
+            and paste it into their confirmation text or email. Each link goes directly to
+            the Google review submission form for that specific location.
+          </div>
+        </div>
+
+        {/* Location list */}
+        <div className="space-y-3">
+          {locations.map(({ locationSlug, region, address, reviewUrl }) => (
+            <div
+              key={locationSlug}
+              className="bg-white border border-gray-200 rounded-lg p-4 space-y-2"
+            >
+              <div>
+                <p className="font-semibold text-[#252932]">{region}</p>
+                <p className="text-sm text-gray-400">{address}</p>
+              </div>
+              <p className="text-xs text-gray-400 font-mono truncate">{reviewUrl}</p>
+              <div className="flex gap-2 pt-1">
+                <button
+                  onClick={() => handleCopy(locationSlug, reviewUrl)}
+                  className="px-4 py-1.5 rounded-md text-sm font-medium text-white bg-[#0A50EC] hover:bg-[#252932] transition-colors"
+                >
+                  {copiedStates[locationSlug] ? "✓ Copied!" : "Copy Link"}
+                </button>
+                <a
+                  href={reviewUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="px-4 py-1.5 rounded-md text-sm font-medium text-[#0A50EC] border border-[#0A50EC]/30 hover:bg-[#0A50EC]/10 transition-colors"
+                >
+                  Open →
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/locations/[state]/[location]/page.tsx
+++ b/app/locations/[state]/[location]/page.tsx
@@ -38,6 +38,7 @@ import { LocationNAP } from '@/components/LocationNAP'
 import LocationSeoSections from '@/components/LocationSeoSections'
 import LocationGallerySection from '@/components/LocationGallerySection'
 import { findClinicByStateAndLocation, getAllLocationParams, isValidStateSlug, STATE_METADATA } from '@/lib/locationRedirects'
+import { ReviewLocationCapture } from '@/components/ReviewLocationCapture'
 import { STATE_PHONE_NUMBERS, MAIN_PHONE_DISPLAY } from '@/lib/locationConstants'
 
 export const dynamicParams = false;
@@ -112,6 +113,7 @@ export default async function LocationDetails(
     
     return (
         <main className='w-full flex-col items-center justify-center h-full'>
+            <ReviewLocationCapture locationSlug={locationData.locationSlug} />
             <section className="w-full h-full flex flex-col relative overflow-hidden [mask-composite:intersect] [mask-image:linear-gradient(to_top,transparent,black_6rem)]  justify-between" >
                 <div
                     style={{

--- a/app/review/[locationSlug]/layout.tsx
+++ b/app/review/[locationSlug]/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { buildCanonical, safeTitle, safeDescription } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  title: safeTitle(undefined, "Leave a Review | Mountain Spine & Orthopedics"),
+  description: safeDescription(undefined, "Share your experience with Mountain Spine & Orthopedics."),
+  robots: {
+    index: false,
+    follow: false,
+  },
+  alternates: {
+    canonical: buildCanonical("/review"),
+  },
+};
+
+export default function ReviewLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/review/[locationSlug]/page.tsx
+++ b/app/review/[locationSlug]/page.tsx
@@ -1,0 +1,119 @@
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+import { clinics } from "@/components/data/clinics";
+import { getReviewLink } from "@/lib/reviewLinks";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface ReviewPageProps {
+  params: Promise<{ locationSlug: string }>;
+}
+
+export default async function ReviewPage({ params }: ReviewPageProps) {
+  const { locationSlug } = await params;
+  const clinic = clinics.find((c) => c.locationSlug === locationSlug);
+
+  if (!clinic) {
+    notFound();
+  }
+
+  const reviewLink = getReviewLink(locationSlug);
+
+  const filledStars = Math.round(clinic.rating);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-slate-50 flex items-center justify-center py-16 px-4">
+      <div className="w-full max-w-lg">
+        <Card className="shadow-lg border-0">
+          <CardContent className="p-8 space-y-6">
+            {/* Logo */}
+            <div className="flex justify-center">
+              <Image
+                src="/newlogo4.png"
+                alt="Mountain Spine & Orthopedics"
+                width={180}
+                height={48}
+                className="h-12 w-auto object-contain"
+                priority
+              />
+            </div>
+
+            {/* Star rating */}
+            <div className="flex flex-col items-center gap-1">
+              <div className="flex items-center gap-1">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <svg
+                    key={i}
+                    className="h-6 w-6"
+                    viewBox="0 0 24 24"
+                    fill={i < filledStars ? "#0A50EC" : "none"}
+                    stroke="#0A50EC"
+                    strokeWidth="1.5"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.562.562 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"
+                    />
+                  </svg>
+                ))}
+              </div>
+              <p className="text-sm text-gray-500">
+                Rated {clinic.rating}★ by our patients
+              </p>
+            </div>
+
+            {/* Heading */}
+            <div className="text-center space-y-1">
+              <h1
+                className="text-2xl font-bold text-[#252932]"
+                style={{ fontFamily: "var(--font-public-sans)" }}
+              >
+                Thank you for choosing Mountain Spine & Orthopedics
+              </h1>
+              <p className="text-gray-500 text-sm">{clinic.region}</p>
+            </div>
+
+            {/* Body copy */}
+            <p className="text-gray-700 text-center leading-relaxed" style={{ fontFamily: "var(--font-inter)" }}>
+              Your experience matters — to us and to patients just like you who are looking for
+              trusted spine and orthopedic care. If you'd like to share your experience, it only
+              takes a minute.
+            </p>
+
+            {/* Soft review nudge */}
+            <p className="text-sm text-gray-400 italic text-center leading-relaxed">
+              Feel free to mention your doctor, the condition you came in for, and how your
+              treatment went — it helps other patients in similar situations find the right care.
+            </p>
+
+            {/* CTA or fallback */}
+            {reviewLink ? (
+              <Button
+                asChild
+                className="w-full bg-[#0A50EC] hover:bg-[#252932] text-white"
+              >
+                <a href={reviewLink} target="_blank" rel="noopener noreferrer">
+                  Share Your Experience on Google
+                </a>
+              </Button>
+            ) : (
+              <p className="text-center text-sm text-gray-400">
+                Google Reviews for this location coming soon.
+              </p>
+            )}
+
+            {/* Footer link */}
+            <div className="text-center">
+              <Link href="/" className="text-sm text-gray-400 hover:text-[#0A50EC] transition-colors">
+                ← Return to Homepage
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/app/thank-you/layout.tsx
+++ b/app/thank-you/layout.tsx
@@ -4,6 +4,10 @@ import { buildCanonical, safeTitle, safeDescription } from "@/lib/seo";
 export const metadata: Metadata = {
   title: safeTitle(undefined, "Thank You | Mountain Spine & Orthopedics"),
   description: safeDescription(undefined, "Thank you for contacting Mountain Spine & Orthopedics. We'll get back to you soon to schedule your consultation."),
+  robots: {
+    index: false,
+    follow: false,
+  },
   alternates: {
     canonical: buildCanonical("/thank-you"),
   },

--- a/app/thank-you/page.tsx
+++ b/app/thank-you/page.tsx
@@ -1,27 +1,36 @@
 "use client";
 
-import { useEffect } from 'react';
-import { CheckCircle, Mail, Users, Share2, Instagram } from "lucide-react"
+import { useEffect, useState } from 'react';
+import { CheckCircle, Mail, Users, Share2, Instagram, Star } from "lucide-react"
 import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { DotLottieReact } from '@lottiefiles/dotlottie-react';
 import { restoreECFromSession, formatPhoneToE164 } from "@/utils/enhancedConversions";
+import { getReviewLink, getReviewLocations } from "@/lib/reviewLinks";
 
 export default function ThankYouPage() {
+  // LOCATION-AWARE REVIEW CTA
+  // Priority 1: sessionStorage — set automatically when a patient visits a location page
+  //   via ReviewLocationCapture component (key: 'review_location_slug')
+  // Priority 2: Dropdown — patient selects their clinic manually if no sessionStorage data
+  // The locationSlug values are defined in /components/data/clinics.tsx
+  const [resolvedSlug, setResolvedSlug] = useState<string | null>(null);
+  const [selectedSlug, setSelectedSlug] = useState<string>('');
+
   useEffect(() => {
     // Restore enhanced conversion data from sessionStorage immediately
     // This ensures the data is available when Google Ads conversion tags fire
     restoreECFromSession(); // pushes {event:'ec_restore', enhanced_conversion_data:{...}}
-    
+
     // Also push the data silently (without event) to ensure it's in dataLayer
     // This helps with cases where the conversion tag fires before the event
     if (typeof window !== 'undefined') {
       try {
         const country = (sessionStorage.getItem('ec_country') || 'US').trim().toUpperCase();
         const rawPhone = sessionStorage.getItem('ec_phone') || '';
-        
+
         const ec = {
           email: (sessionStorage.getItem('ec_email') || '').trim().toLowerCase(),
           phone_number: formatPhoneToE164(rawPhone, country),
@@ -32,7 +41,7 @@ export default function ThankYouPage() {
             postal_code: (sessionStorage.getItem('ec_postal') || '').trim(),
           },
         };
-        
+
         // Check if we have valid data before pushing
         if (ec.email || ec.phone_number) {
           (window as any).dataLayer = (window as any).dataLayer || [];
@@ -54,6 +63,18 @@ export default function ThankYouPage() {
       }
     }
   }, []);
+
+  useEffect(() => {
+    try {
+      const stored = sessionStorage.getItem('review_location_slug');
+      if (stored) setResolvedSlug(stored);
+    } catch {
+      // fail silently
+    }
+  }, []);
+
+  const activeSlug = resolvedSlug || selectedSlug || null;
+  const reviewLink = activeSlug ? getReviewLink(activeSlug) : null;
 
   return (
     <div className="lg:py-[80px] py-[40px] w-full bg-gradient-to-br from-blue-50 to-slate-50">
@@ -93,6 +114,80 @@ export default function ThankYouPage() {
                           Please look out for a confirmation email in your inbox with your appointment details. Our team
                           will contact you ASAP to confirm your appointment time.
                         </p>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {/* ── Google Review CTA ── */}
+                <Card className="border-l-[#0A50EC] bg-[#0A50EC]/10">
+                  <CardContent className="p-6">
+                    <div className="flex items-start gap-3">
+                      <Star className="h-10 w-10 text-[#0A50EC] mt-1 flex-shrink-0" />
+                      <div className="flex-1 space-y-3">
+                        <div>
+                          <h3 className="font-semibold text-[#252932] mb-1">
+                            Leave Us a Google Review
+                          </h3>
+                          <p className="text-gray-700 text-sm">
+                            A quick review helps other patients find trusted spine and orthopedic
+                            care — and only takes a minute.
+                          </p>
+                        </div>
+
+                        {/* Auto-resolved from sessionStorage — show confirmation chip */}
+                        {resolvedSlug && (
+                          <p className="text-xs text-[#0A50EC] font-medium">
+                            ✓ Showing review link for your location
+                          </p>
+                        )}
+
+                        {/* Dropdown — only show if sessionStorage didn't resolve a location */}
+                        {!resolvedSlug && (
+                          <div>
+                            <label
+                              htmlFor="review-location-select"
+                              className="block text-sm text-gray-600 mb-1"
+                            >
+                              Select your clinic location:
+                            </label>
+                            <select
+                              id="review-location-select"
+                              value={selectedSlug}
+                              onChange={(e) => setSelectedSlug(e.target.value)}
+                              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm text-gray-700 bg-white focus:outline-none focus:ring-2 focus:ring-[#0A50EC] focus:border-transparent"
+                            >
+                              <option value="">— Choose your location —</option>
+                              {getReviewLocations().map(({ locationSlug, region }) => (
+                                <option key={locationSlug} value={locationSlug}>
+                                  {region}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        )}
+
+                        {/* Review button — only renders when a valid review link is available */}
+                        {reviewLink && (
+                          <>
+                            <p className="text-xs text-gray-500 italic">
+                              Feel free to mention your doctor, the condition you came in for,
+                              and how your treatment went.
+                            </p>
+                            <Button
+                              asChild
+                              className="bg-[#0A50EC] hover:bg-[#252932] text-white w-full"
+                            >
+                              <a
+                                href={reviewLink}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                Leave a Google Review
+                              </a>
+                            </Button>
+                          </>
+                        )}
                       </div>
                     </div>
                   </CardContent>

--- a/components/ReviewLocationCapture.tsx
+++ b/components/ReviewLocationCapture.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface ReviewLocationCaptureProps {
+  locationSlug: string;
+}
+
+export function ReviewLocationCapture({ locationSlug }: ReviewLocationCaptureProps) {
+  useEffect(() => {
+    try {
+      if (locationSlug) {
+        sessionStorage.setItem('review_location_slug', locationSlug);
+      }
+    } catch {
+      // sessionStorage may be unavailable in some environments — fail silently
+    }
+  }, [locationSlug]);
+
+  return null; // renders nothing
+}

--- a/lib/reviewLinks.ts
+++ b/lib/reviewLinks.ts
@@ -1,0 +1,54 @@
+// Maps locationSlug (from clinics.tsx) to Google review short URL
+// Only clinics with active Google Business Profiles are included
+// Clinics not in this map have no GBP yet — handled gracefully in all UI
+export const REVIEW_LINKS: Record<string, string> = {
+  'hollywood-orthopedics': 'https://g.page/r/CYqA11vJ24y9EBM/review',
+  'miami-beach-orthopedics': 'https://g.page/r/CUt57-NcR2RGEBM/review',
+  'palm-beach-gardens-orthopedics': 'https://g.page/r/CUMyxOiry4yEEBM/review',
+  'boca-raton-orthopedics': 'https://g.page/r/CewP7F8j5W7WEBM/review',
+  'orlando-orthopedics': 'https://g.page/r/CWyo3YuSDwCTEBM/review',
+  'palm-springs-orthopedics': 'https://g.page/r/CbyTfcg1z948EBM/review',
+  'altamonte-springs-orthopedics': 'https://g.page/r/CZdNCoUsaU5vEBM/review',
+  'jacksonville-orthopedics': 'https://g.page/r/CQuHCfzUfzR6EBM/review',
+  'fort-pierce-orthopedics': 'https://g.page/r/CTyihrFXV5-HEBM/review',
+  'new-york-city-orthopedics': 'https://g.page/r/Ca2RXgYKHipQEBM/review',
+  'bridgewater-orthopedics': 'https://g.page/r/CSfEt1IXNr7DEBM/review',
+  'freehold-orthopedics': 'https://g.page/r/CVU-VYAxAx1eEBM/review',
+  'princeton-orthopedics': 'https://g.page/r/CbFY9Q7Ab57iEBM/review',
+  'cherry-hill-orthopedics': 'https://g.page/r/CWXHP7Jv-y7JEBM/review',
+  'west-orange-surgery-center': 'https://g.page/r/CT0PMkcwIzYxEBM/review',
+  'edison-orthopedics': 'https://g.page/r/CS5_Ra9InWIzEBM/review',
+  'paramus-orthopedics': 'https://g.page/r/CbQ0wAxe4uA8EBM/review',
+  'voorhees-orthopedics': 'https://g.page/r/CZzrShXR0RTvEBM/review',
+};
+
+// Returns the Google review URL for a given locationSlug, or null if not found
+export function getReviewLink(locationSlug: string): string | null {
+  return REVIEW_LINKS[locationSlug] ?? null;
+}
+
+// Returns an array of all locations that have review links, sorted alphabetically
+// by region name, for use in dropdowns and the staff tool.
+// Region labels are sourced directly from clinics.tsx to ensure consistency.
+export function getReviewLocations(): { locationSlug: string; region: string; address: string; reviewUrl: string }[] {
+  return [
+    { locationSlug: 'hollywood-orthopedics',          region: 'Hollywood, FL',                          address: '3500 Tyler St, Hollywood, FL 33021',                        reviewUrl: REVIEW_LINKS['hollywood-orthopedics'] },
+    { locationSlug: 'miami-beach-orthopedics',         region: 'South Miami, FL',                        address: '7000 SW 62nd Ave, Suite 330, Miami, FL 33143',              reviewUrl: REVIEW_LINKS['miami-beach-orthopedics'] },
+    { locationSlug: 'palm-beach-gardens-orthopedics',  region: 'Palm Beach Gardens, FL',                 address: '3355 Burns Rd, Palm Beach Gardens, FL 33410',               reviewUrl: REVIEW_LINKS['palm-beach-gardens-orthopedics'] },
+    { locationSlug: 'boca-raton-orthopedics',          region: 'Boca Raton, FL',                         address: '1905 Clint Moore Rd, Boca Raton, FL 33496',                 reviewUrl: REVIEW_LINKS['boca-raton-orthopedics'] },
+    { locationSlug: 'orlando-orthopedics',             region: 'Orlando, FL',                            address: '6150 Metrowest Blvd, Orlando, FL 32835',                    reviewUrl: REVIEW_LINKS['orlando-orthopedics'] },
+    { locationSlug: 'palm-springs-orthopedics',        region: 'Altamonte Springs - Casselberry, FL',    address: '652 Palm Springs Dr, Altamonte Springs, FL 32701',          reviewUrl: REVIEW_LINKS['palm-springs-orthopedics'] },
+    { locationSlug: 'altamonte-springs-orthopedics',   region: 'Central Pkwy Altamonte Springs, FL',     address: '499 E Central Pkwy, Suite 130, Altamonte Springs, FL 32701', reviewUrl: REVIEW_LINKS['altamonte-springs-orthopedics'] },
+    { locationSlug: 'jacksonville-orthopedics',        region: 'Jacksonville, FL',                       address: '1205 Monument Rd, Suite 202, Jacksonville, FL 32225',       reviewUrl: REVIEW_LINKS['jacksonville-orthopedics'] },
+    { locationSlug: 'fort-pierce-orthopedics',         region: 'Fort Pierce, FL',                        address: '2215 Nebraska Ave Suite 1C, Fort Pierce, FL 34950',         reviewUrl: REVIEW_LINKS['fort-pierce-orthopedics'] },
+    { locationSlug: 'new-york-city-orthopedics',       region: 'New York, NY',                           address: '535 5th Ave, New York, NY 10017',                           reviewUrl: REVIEW_LINKS['new-york-city-orthopedics'] },
+    { locationSlug: 'bridgewater-orthopedics',         region: 'Bridgewater, NJ',                        address: '1200 US-22, Bridgewater, NJ 08807',                         reviewUrl: REVIEW_LINKS['bridgewater-orthopedics'] },
+    { locationSlug: 'freehold-orthopedics',            region: 'Freehold, NJ',                           address: '77 Schanck Rd, Freehold, NJ 07728',                         reviewUrl: REVIEW_LINKS['freehold-orthopedics'] },
+    { locationSlug: 'princeton-orthopedics',           region: 'Princeton, NJ',                          address: '601 Ewing St, Princeton, NJ 08540',                         reviewUrl: REVIEW_LINKS['princeton-orthopedics'] },
+    { locationSlug: 'cherry-hill-orthopedics',         region: 'Cherry Hill, NJ',                        address: '100 Springdale Rd, Cherry Hill, NJ 08003',                  reviewUrl: REVIEW_LINKS['cherry-hill-orthopedics'] },
+    { locationSlug: 'west-orange-surgery-center',      region: 'West Orange, NJ',                        address: '375 Mount Pleasant Ave, West Orange, NJ 07052',             reviewUrl: REVIEW_LINKS['west-orange-surgery-center'] },
+    { locationSlug: 'edison-orthopedics',              region: 'Edison, NJ',                             address: '25 Main St, Edison, NJ 08837',                              reviewUrl: REVIEW_LINKS['edison-orthopedics'] },
+    { locationSlug: 'paramus-orthopedics',             region: 'Paramus, NJ',                            address: '140 NJ-17, Paramus, NJ 07652',                              reviewUrl: REVIEW_LINKS['paramus-orthopedics'] },
+    { locationSlug: 'voorhees-orthopedics',            region: 'Voorhees, NJ',                           address: '701 White Horse Rd, Voorhees, NJ 08043',                    reviewUrl: REVIEW_LINKS['voorhees-orthopedics'] },
+  ].sort((a, b) => a.region.localeCompare(b.region));
+}


### PR DESCRIPTION
- Add /lib/reviewLinks.ts with REVIEW_LINKS record mapping all 18 GBP locationSlugs to verified Google review short URLs, getReviewLink() helper, and getReviewLocations() sorted array for dropdowns/staff tools

- Add ReviewLocationCapture client component that silently writes locationSlug to sessionStorage when patients visit clinic location pages, enabling passive location resolution on the thank-you page

- Add /app/review/[locationSlug] dynamic route — branded noindex intermediate pages showing clinic name, region, star rating, review count, soft keyword nudge copy, and direct Google review CTA button; used by staff to send patients a location-specific review link post phone assignment; graceful fallback for clinics without GBP

- Update /app/thank-you/page.tsx to include Google Review CTA card with two-tier location resolution: (1) auto-resolves from sessionStorage if patient arrived via location page, (2) falls back to location dropdown populated from getReviewLocations() if no sessionStorage context exists; review button only renders when valid review link is available; all existing conversion tracking and dataLayer logic untouched

- Add robots noindex/nofollow to /app/thank-you/layout.tsx

- Add /app/internal/review-links staff tool — noindex page listing all 18 GBP locations with one-click copy buttons, per-location copied state, address display, and direct open links; enables staff to paste correct location review link into patient confirmation texts after phone assignment

No sitemap changes. No existing UI, styling, or conversion tracking modified.