### PR TITLE
fix: complete GCLID & UTM attribution pipeline across all forms

### DIFF
--- a/app/find-care/free-mri-review/FreeMRIReviewClient.tsx
+++ b/app/find-care/free-mri-review/FreeMRIReviewClient.tsx
@@ -36,10 +36,11 @@ import DoctorsTestitmonial from '@/components/DoctorsTestitmonial';
 import { TextAnimate } from '@/components/magicui/text-animate'
 import { Marquee } from '@/components/magicui/marquee'
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
-import { sendMRIContactEmail, sendUserEmail } from '@/components/email/sendcontactemail'
+import { sendMRIContactEmail } from '@/components/email/sendcontactemail'
 import { redirect } from 'next/navigation'
 import { pushFormSubmit } from '@/utils/enhancedConversions'
 import { normalizeState } from '@/lib/stateUtils'
+import { getAttributionData } from '@/lib/gclid'
 
 const formSchema = z.object({
   // Step 1 Questions
@@ -219,6 +220,12 @@ export default function FreeMRIReviewClient() {
   const [ConditionStep, setConditionStep] = useState(1)
   const [openAppointmentConfirm, setAppointmentConfirm] = useState(false)
   const [disabled, setDisabled] = useState(false)
+  const [attribution, setAttribution] = useState({ gclid: '', utm_source: '', utm_medium: '', utm_campaign: '', utm_term: '', utm_content: '' })
+
+  React.useEffect(() => {
+    setAttribution(getAttributionData())
+  }, [])
+
   const ConditionForm = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -238,8 +245,15 @@ export default function FreeMRIReviewClient() {
   })
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setDisabled(true)
-    await sendUserEmail({ name: values.first_name + " " + values.last_name, email: values.email, phone: values.phone })
-    const data = await sendMRIContactEmail(values)
+    const data = await sendMRIContactEmail({
+      ...values,
+      gclid: attribution.gclid,
+      utm_source: attribution.utm_source,
+      utm_medium: attribution.utm_medium,
+      utm_campaign: attribution.utm_campaign,
+      utm_term: attribution.utm_term,
+      utm_content: attribution.utm_content,
+    })
     if (data) {
       pushFormSubmit({ form_name: 'FreeMRIReviewForm', state: normalizeState(values.state), email: values.email, phone: values.phone, firstName: values.first_name, lastName: values.last_name })
       ConditionForm.reset()

--- a/app/injuries/car-accident/lead-capture-form.tsx
+++ b/app/injuries/car-accident/lead-capture-form.tsx
@@ -92,7 +92,20 @@ export function CarAccidentLeadCaptureForm() {
     async function onSubmit(values: z.infer<typeof leadSchema>) {
         setIsSubmitting(true)
         const data = await sendContactEmail({ name: values.firstName, email: values.email, phone: values.phone, reason: values.injuryType, bestTime: values.painLevel, has_attorney: values.hasAttorney, injury_type: values.injuryType, pain_level: values.painLevel, location: values.location, state: values.state, gclid: attribution.gclid, utm_source: attribution.utm_source, utm_medium: attribution.utm_medium, utm_campaign: attribution.utm_campaign, utm_term: attribution.utm_term, utm_content: attribution.utm_content })
-        await sendUserEmail({ name: values.firstName, email: values.email, phone: values.phone })
+        await sendUserEmail({
+            name: values.firstName,
+            email: values.email,
+            phone: values.phone,
+            state: values.state,
+            reason: values.injuryType,
+            form_source: 'car-accident',
+            gclid: attribution.gclid,
+            utm_source: attribution.utm_source,
+            utm_medium: attribution.utm_medium,
+            utm_campaign: attribution.utm_campaign,
+            utm_term: attribution.utm_term,
+            utm_content: attribution.utm_content,
+        })
         
         // Enhanced Conversions
         pushFormSubmit({ form_name: 'CarAccidentLeadForm', state: values.state, email: values.email, phone: values.phone, firstName: values.firstName, lastName: values.lastName });

--- a/app/injuries/personal-injury/lead-capture-form.tsx
+++ b/app/injuries/personal-injury/lead-capture-form.tsx
@@ -92,7 +92,20 @@ export function PersonalInjuryLeadCaptureForm() {
       utm_term: attribution.utm_term,
       utm_content: attribution.utm_content,
     })
-    await sendUserEmail({ name: values.firstName, email: values.email, phone: values.phone })
+    await sendUserEmail({
+      name: values.firstName,
+      email: values.email,
+      phone: values.phone,
+      state: values.state,
+      reason: values.injury,
+      form_source: 'personal-injury',
+      gclid: attribution.gclid,
+      utm_source: attribution.utm_source,
+      utm_medium: attribution.utm_medium,
+      utm_campaign: attribution.utm_campaign,
+      utm_term: attribution.utm_term,
+      utm_content: attribution.utm_content,
+    })
 
     pushFormSubmit({ form_name: 'PersonalInjuryLeadForm', state: values.state, email: values.email, phone: values.phone, firstName: values.firstName, lastName: values.lastName })
 

--- a/app/injuries/slip-and-fall/lead-capture-form.tsx
+++ b/app/injuries/slip-and-fall/lead-capture-form.tsx
@@ -72,7 +72,20 @@ export function LeadCaptureForm() {
     async function onSubmit(values: z.infer<typeof leadSchema>) {
         setIsSubmitting(true)
         const data = await sendContactEmail({ name: values.firstName, email: values.email, phone: values.phone, reason: values.injury, bestTime: values.urgency, injury_type: values.injury, location: values.location, state: values.state, gclid: attribution.gclid, utm_source: attribution.utm_source, utm_medium: attribution.utm_medium, utm_campaign: attribution.utm_campaign, utm_term: attribution.utm_term, utm_content: attribution.utm_content })
-        await sendUserEmail({ name: values.firstName, email: values.email, phone: values.phone })
+        await sendUserEmail({
+            name: values.firstName,
+            email: values.email,
+            phone: values.phone,
+            state: values.state,
+            reason: values.injury,
+            form_source: 'slip-and-fall',
+            gclid: attribution.gclid,
+            utm_source: attribution.utm_source,
+            utm_medium: attribution.utm_medium,
+            utm_campaign: attribution.utm_campaign,
+            utm_term: attribution.utm_term,
+            utm_content: attribution.utm_content,
+        })
         
         // Enhanced Conversions
         pushFormSubmit({ form_name: 'SlipAndFallLeadForm', state: values.state, email: values.email, phone: values.phone, firstName: values.firstName, lastName: values.lastName });

--- a/app/injuries/work-injury/lead-capture-form.tsx
+++ b/app/injuries/work-injury/lead-capture-form.tsx
@@ -92,7 +92,20 @@ export function WorkInjuryLeadCaptureForm() {
             utm_term: attribution.utm_term,
             utm_content: attribution.utm_content,
         })
-        await sendUserEmail({ name: values.firstName, email: values.email, phone: values.phone })
+        await sendUserEmail({
+            name: values.firstName,
+            email: values.email,
+            phone: values.phone,
+            state: values.state,
+            reason: values.injury,
+            form_source: 'work-injury',
+            gclid: attribution.gclid,
+            utm_source: attribution.utm_source,
+            utm_medium: attribution.utm_medium,
+            utm_campaign: attribution.utm_campaign,
+            utm_term: attribution.utm_term,
+            utm_content: attribution.utm_content,
+        })
 
         pushFormSubmit({ form_name: 'WorkInjuryLeadForm', state: values.state, email: values.email, phone: values.phone, firstName: values.firstName, lastName: values.lastName })
 

--- a/components/BookAnAppointmentPopup.tsx
+++ b/components/BookAnAppointmentPopup.tsx
@@ -15,10 +15,11 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import BookAnAppoitmentButton from "./BookAnAppoitmentButton"
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "./ui/dialog"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import BookAnAppointmentClient from "./BookAnAppointmentClient"
-import { sendContactEmail, sendUserEmail } from "./email/sendcontactemail"
 import Link from "next/link"
+import { getAttributionData } from "@/lib/gclid"
+import { useRouter } from "next/navigation"
 const formSchema = z.object({
     name: z.string().min(2, "name must be at least 2 characters"),
     email: z.string().email("Invalid email address"),
@@ -39,6 +40,13 @@ export default function BookAnAppointmentPopup() {
     const [openContactForm, setOpenContactForm] = useState(false)
     const [openAppointmentConfirm, setAppointmentConfirm] = useState(false)
     const [loading, setLoading] = useState(false)
+    const [attribution, setAttribution] = useState({ gclid: '', utm_source: '', utm_medium: '', utm_campaign: '', utm_term: '', utm_content: '' })
+    const router = useRouter()
+
+    useEffect(() => {
+        setAttribution(getAttributionData())
+    }, [])
+
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema),
         defaultValues: {
@@ -51,15 +59,50 @@ export default function BookAnAppointmentPopup() {
     })
 
 
+    async function serializeFile(file: File | null | undefined): Promise<{ name: string; type: string; base64: string } | null> {
+        if (!file) return null;
+        const buffer = await file.arrayBuffer();
+        const bytes = new Uint8Array(buffer);
+        let binary = '';
+        bytes.forEach(b => { binary += String.fromCharCode(b); });
+        return { name: file.name, type: file.type, base64: btoa(binary) };
+    }
+
     async function onSubmit(values: z.infer<typeof formSchema>) {
         try {
             setLoading(true)
-            console.log('Called')
-            // Do something with the form values.
-            // ✅ This will be type-safe and validated.
-            console.log(values)
-            await sendUserEmail(values)
-            await sendContactEmail(values)
+
+            const [insuranceCardFront, insuranceCardBack] = await Promise.all([
+                serializeFile(values.insuranceCardFront),
+                serializeFile(values.insuranceCardBack),
+            ]);
+
+            const res = await fetch('/api/forms/book-appointment', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    firstName: values.name.split(' ')[0] || values.name,
+                    lastName: values.name.split(' ').slice(1).join(' ') || '',
+                    email: values.email,
+                    phone: values.phone,
+                    reason: values.reason,
+                    bestTime: values.bestTime,
+                    form_source: 'book-appointment',
+                    insuranceCardFront,
+                    insuranceCardBack,
+                    gclid: attribution.gclid,
+                    utm_source: attribution.utm_source,
+                    utm_medium: attribution.utm_medium,
+                    utm_campaign: attribution.utm_campaign,
+                    utm_term: attribution.utm_term,
+                    utm_content: attribution.utm_content,
+                }),
+            })
+
+            if (res.redirected) {
+                router.push(res.url)
+                return
+            }
 
             if (typeof window !== 'undefined' && window.dataLayer) {
                 window.dataLayer.push({
@@ -69,7 +112,7 @@ export default function BookAnAppointmentPopup() {
                 });
             }
 
-            setAppointmentConfirm(true)
+            router.push('/thank-you')
         } catch (error) {
             console.error('Error submitting form:', error)
         } finally {

--- a/components/BookAnAppoitmentButton.tsx
+++ b/components/BookAnAppoitmentButton.tsx
@@ -25,6 +25,7 @@ import Link from 'next/link'
 import { useRouter, usePathname } from 'next/navigation'
 import { pushFormSubmit } from "@/utils/enhancedConversions"
 import { STATE_OPTIONS, slugFromPathname, normalizeState } from "@/lib/stateUtils"
+import { getAttributionData } from "@/lib/gclid"
 import { ScrollProgress } from "@/components/ui/scroll-progress"
 import { FileUpload } from './ui/file-upload'
 const formSchema = z.object({
@@ -78,6 +79,7 @@ export default function BookAnAppoitmentButton({
     const [openAppointmentConfirm, setAppointmentConfirm] = useState(false)
     const [disabled, setDisabled] = useState(false)
     const [showScrollIndicator, setShowScrollIndicator] = useState(true)
+    const [attribution, setAttribution] = useState({ gclid: '', utm_source: '', utm_medium: '', utm_campaign: '', utm_term: '', utm_content: '' })
     const router = useRouter()
     const pathname = usePathname()
     const resolvedState = slugFromPathname(pathname)
@@ -98,6 +100,10 @@ export default function BookAnAppoitmentButton({
             state: resolvedState,
         },
     })
+
+    useEffect(() => {
+        setAttribution(getAttributionData())
+    }, [])
 
     const handleOpen = () => {
         console.log('Opening dialog...')
@@ -214,6 +220,12 @@ export default function BookAnAppoitmentButton({
                 state: values.state,
                 insuranceCardFront: await toFilePayload(values.insuranceCardFront),
                 insuranceCardBack: await toFilePayload(values.insuranceCardBack),
+                gclid: attribution.gclid,
+                utm_source: attribution.utm_source,
+                utm_medium: attribution.utm_medium,
+                utm_campaign: attribution.utm_campaign,
+                utm_term: attribution.utm_term,
+                utm_content: attribution.utm_content,
             }
 
             const res = await fetch("/api/forms/book-appointment", {

--- a/components/CandidacyCheckClient.tsx
+++ b/components/CandidacyCheckClient.tsx
@@ -34,6 +34,7 @@ const associationLogoAlt: Record<string, string> = {
   'SMIS': 'Society for Minimally Invasive Spine Surgery (SMISS) member'
 };
 import { redirect } from 'next/navigation'
+import { getAttributionData } from '@/lib/gclid'
 // Reverted form schema to match the "Candidacy Check" steps from the image
 const formSchema = z.object({
   // Step 1 Questions
@@ -144,6 +145,12 @@ export default function CandidacyCheckClient() {
   const [conditionStep, setConditionStep] = useState(1);
   const [appointmentConfirm, setAppointmentConfirm] = useState(false);
   const [disabled, setDisabled] = useState(false)
+  const [attribution, setAttribution] = useState({ gclid: '', utm_source: '', utm_medium: '', utm_campaign: '', utm_term: '', utm_content: '' })
+
+  React.useEffect(() => {
+    setAttribution(getAttributionData())
+  }, [])
+
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -166,8 +173,7 @@ export default function CandidacyCheckClient() {
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setDisabled(true)
-    await sendUserEmail({ name: values.first_name + " " + values.last_name, email: values.email, phone: values.phone });
-    const data = await sendCandidacyEmail({ ...values, email_optout: "false" });
+    const data = await sendCandidacyEmail({ ...values, email_optout: "false", ...attribution });
     if (data) {
       //setAppointmentConfirm(true);
       form.reset();

--- a/components/ConditionCheckSection.tsx
+++ b/components/ConditionCheckSection.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { m, motion } from 'framer-motion'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -9,8 +9,9 @@ import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectVa
 import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
-import { sendConditionCheckEmail, sendUserEmail } from '@/components/email/sendcontactemail'
+import { sendConditionCheckEmail } from '@/components/email/sendcontactemail'
 import { redirect } from 'next/navigation'
+import { getAttributionData } from '@/lib/gclid'
 
 
 const formSchema = z.object({
@@ -64,6 +65,12 @@ export default function ConditionCheckSection({
   const [ConditionStep, setConditionStep] = useState(1)
   const [openAppointmentConfirm, setAppointmentConfirm] = useState(false)
   const [disabled, setDisabled] = useState(false)
+  const [attribution, setAttribution] = useState({ gclid: '', utm_source: '', utm_medium: '', utm_campaign: '', utm_term: '', utm_content: '' })
+
+  useEffect(() => {
+    setAttribution(getAttributionData())
+  }, [])
+
   const ConditionForm = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -91,8 +98,15 @@ export default function ConditionCheckSection({
   })
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setDisabled(true)
-    const data = await sendConditionCheckEmail(values)
-    await sendUserEmail({ name: values.first_name + " " + values.last_name, email: values.email, phone: values.phone })
+    const data = await sendConditionCheckEmail({
+      ...values,
+      gclid: attribution.gclid,
+      utm_source: attribution.utm_source,
+      utm_medium: attribution.utm_medium,
+      utm_campaign: attribution.utm_campaign,
+      utm_term: attribution.utm_term,
+      utm_content: attribution.utm_content,
+    })
     if (data) {
       ConditionForm.reset()
       //setAppointmentConfirm(true)

--- a/components/MiniContactForm.tsx
+++ b/components/MiniContactForm.tsx
@@ -2,40 +2,33 @@
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
-import { format } from "date-fns"
-import { CalendarIcon } from "lucide-react"
+import { useEffect, useState } from "react"
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { Calendar } from "@/components/ui/calendar"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import BookAnAppoitmentButton from "./BookAnAppoitmentButton"
+import { getAttributionData } from "@/lib/gclid"
+import { useRouter } from "next/navigation"
+
 const formSchema = z.object({
   name: z.string().min(2, "name must be at least 2 characters"),
   email: z.string().email("Invalid email address"),
   phone: z.string().min(10, "Phone number must be at least 10 digits"),
   bestTime: z.string().min(1, "Please select a time"),
-  date: z.date({
-    required_error: "Please select a date",
-  }),
-  reason: z.string().min(10, "Please provide more detail about your consultation needs"),
+  reason: z.string().min(2, "Please provide more detail about your consultation needs"),
 })
 
-const timeSlots = [
-  "9:00 AM - 10:00 AM",
-  "10:00 AM - 11:00 AM",
-  "11:00 AM - 12:00 PM",
-  "1:00 PM - 2:00 PM",
-  "2:00 PM - 3:00 PM",
-  "3:00 PM - 4:00 PM",
-  "4:00 PM - 5:00 PM",
-]
-
 export function MiniContactForm({ backgroundcolor = 'white' }: { backgroundcolor?: string }) {
+  const [attribution, setAttribution] = useState({ gclid: '', utm_source: '', utm_medium: '', utm_campaign: '', utm_term: '', utm_content: '' })
+  const [disabled, setDisabled] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    setAttribution(getAttributionData())
+  }, [])
+
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -47,9 +40,43 @@ export function MiniContactForm({ backgroundcolor = 'white' }: { backgroundcolor
     },
   })
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
-    console.log(values)
-    // Handle form submission here
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    setDisabled(true)
+    try {
+      const nameParts = values.name.trim().split(' ')
+      const firstName = nameParts[0] || values.name
+      const lastName = nameParts.slice(1).join(' ') || ''
+      const res = await fetch('/api/forms/consultation', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName,
+          lastName,
+          email: values.email,
+          phone: values.phone,
+          reason: values.reason,
+          bestTime: values.bestTime,
+          form_source: 'state-consultation',
+          gclid: attribution.gclid,
+          utm_source: attribution.utm_source,
+          utm_medium: attribution.utm_medium,
+          utm_campaign: attribution.utm_campaign,
+          utm_term: attribution.utm_term,
+          utm_content: attribution.utm_content,
+        }),
+      })
+      if (res.redirected) {
+        router.push(res.url)
+        return
+      }
+      if (res.ok) {
+        router.push('/thank-you')
+      }
+    } catch (error) {
+      console.error('[MiniContactForm] Submit failed', error)
+    } finally {
+      setDisabled(false)
+    }
   }
 
   return (

--- a/components/email/sendcontactemail.ts
+++ b/components/email/sendcontactemail.ts
@@ -96,7 +96,7 @@ export async function sendUserEmail(formData: {
       state:         formData.state,
       reason:        formData.reason,
       best_time:     formData.bestTime,
-      form_source:   formData.form_source || 'book-appointment',
+      form_source:   formData.form_source || 'unknown',
       gclid:         formData.gclid,
       utm_source:    formData.utm_source,
       utm_medium:    formData.utm_medium,


### PR DESCRIPTION
WHAT WAS BROKEN
Google Ads offline conversion tracking was partially or fully broken across 11 form components. Patient leads submitted through most forms were reaching Supabase with NULL attribution columns (gclid, utm_source, utm_medium, utm_campaign, utm_term, utm_content), making it impossible to tie ad spend to real patient conversions in Google Ads.

The two most critical breaks:

1. MiniContactForm — the submit handler was literally `console.log(values)`. This form has NEVER sent a real submission in production. Zero emails, zero Supabase rows, zero leads captured from this form ever.

2. BookAnAppointmentPopup — was importing and calling server action functions directly inside a 'use client' component. This bypasses the API route entirely, meaning insurance card uploads couldn't be serialized and the full attribution payload was never constructed correctly. Also silently dropped File objects when converted to JSON.

WHAT WAS FIXED
- MiniContactForm: Rewrote onSubmit to POST to /api/forms/consultation with all patient fields + all 6 attribution fields + form_source. Added attribution state, getAttributionData import, and useEffect.

- BookAnAppointmentPopup: Removed server action imports. Rewrote onSubmit to fetch('/api/forms/book-appointment'). Added serializeFile() helper that converts File objects to base64 (btoa) so insurance card images can pass through JSON to the API route's existing toFileLike() handler. Added form_source: 'book-appointment' and all 6 attribution fields.

- CandidacyCheckClient, ConditionCheckSection, FreeMRIReviewClient: Eliminated double-logging bug — each was calling both sendUserEmail AND a specialized email function, causing 2 Supabase rows per submission. Removed the redundant sendUserEmail call, passed attribution to the correct specialized function instead.

- personal-injury, car-accident, work-injury, slip-and-fall lead forms: sendUserEmail was called with only name/email/phone. Added state, reason, form_source (per injury type), and all 6 attribution fields.

- BookAnAppoitmentButton: Added attribution state, useEffect, and all 6 attribution fields to the /api/forms/book-appointment payload.

- sendcontactemail.ts: Changed form_source fallback from 'book-appointment' (wrong for every other form) to 'unknown'. Added attribution field types to sendMRIContactEmail, sendCandidacyEmail, sendConditionCheckEmail.

WHY THIS MATTERS
Every form submission from a Google Ads click must store the GCLID in Supabase so it can be uploaded back to Google Ads as an offline conversion. Without this, Google Ads has no signal that the ad click became a real patient — bidding algorithms can't optimize, and we can't measure true cost per patient acquisition.