### PR TITLE
fix(mobile): align phone button width to form, improve mobile stats &…

### DIFF
--- a/app/api/forms/book-appointment/route.ts
+++ b/app/api/forms/book-appointment/route.ts
@@ -1,57 +1,35 @@
 import { NextResponse } from "next/server";
 import { geolocation } from "@vercel/functions";
-import { Buffer } from "buffer";
 import {
   sendContactEmail,
   sendUserEmail,
 } from "@/components/email/sendcontactemail";
 
-type FilePayload = {
-  name: string;
-  type?: string;
-  base64: string;
-} | null;
+const MAX_UPLOAD_SIZE = 4 * 1024 * 1024;
 
-type BookAppointmentPayload = {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone: string;
-  reason: string;
-  bestTime: string;
-  postalCode?: string;
-  country?: string;
-  state?: string;
-  insuranceCardFront?: FilePayload;
-  insuranceCardBack?: FilePayload;
-  gclid?: string;
-  utm_source?: string;
-  utm_medium?: string;
-  utm_campaign?: string;
-  utm_term?: string;
-  utm_content?: string;
-};
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
 
-type FileLike = {
-  name: string;
-  arrayBuffer: () => Promise<ArrayBuffer>;
-};
+function getUpload(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return value instanceof File && value.size > 0 ? value : undefined;
+}
 
-function toFileLike(file?: FilePayload): FileLike | undefined {
-  if (!file) {
-    return undefined;
-  }
+function validateUpload(file?: File) {
+  return !file || file.size <= MAX_UPLOAD_SIZE;
+}
 
-  const buffer = Buffer.from(file.base64, "base64");
-  const arrayBuffer = buffer.buffer.slice(
-    buffer.byteOffset,
-    buffer.byteOffset + buffer.byteLength,
+function validateTotalUploads(...files: Array<File | undefined>) {
+  return files.reduce((total, file) => total + (file?.size || 0), 0) <= MAX_UPLOAD_SIZE;
+}
+
+export async function GET() {
+  return NextResponse.json(
+    { ok: false, message: "Method not allowed" },
+    { status: 405, headers: { Allow: "POST" } },
   );
-
-  return {
-    name: file.name,
-    arrayBuffer: async () => arrayBuffer,
-  };
 }
 
 export async function POST(request: Request) {
@@ -65,41 +43,61 @@ export async function POST(request: Request) {
   }
 
   try {
-    const body: BookAppointmentPayload = await request.json();
+    const formData = await request.formData();
+    const insuranceCardFront = getUpload(formData, "insuranceCardFront");
+    const insuranceCardBack = getUpload(formData, "insuranceCardBack");
 
-    const fullName = `${body.firstName} ${body.lastName}`.trim();
+    if (
+      !validateUpload(insuranceCardFront) ||
+      !validateUpload(insuranceCardBack) ||
+      !validateTotalUploads(insuranceCardFront, insuranceCardBack)
+    ) {
+      return NextResponse.json(
+        { ok: false, message: "Uploaded file is too large." },
+        { status: 413 },
+      );
+    }
+
+    const firstName = getString(formData, "firstName");
+    const lastName = getString(formData, "lastName");
+    const email = getString(formData, "email");
+    const phone = getString(formData, "phone");
+    const reason = getString(formData, "reason");
+    const bestTime = getString(formData, "bestTime");
+    const state = getString(formData, "state");
+    const fullName = `${firstName} ${lastName}`.trim();
 
     await sendContactEmail({
       name: fullName,
-      email: body.email,
-      phone: body.phone,
-      reason: body.reason,
-      bestTime: body.bestTime,
-      state: body.state,
-      insuranceCardFront: toFileLike(body.insuranceCardFront) as any,
-      insuranceCardBack: toFileLike(body.insuranceCardBack) as any,
-      gclid: body.gclid,
-      utm_source: body.utm_source,
-      utm_medium: body.utm_medium,
-      utm_campaign: body.utm_campaign,
-      utm_term: body.utm_term,
-      utm_content: body.utm_content,
+      email,
+      phone,
+      reason,
+      bestTime,
+      state,
+      insuranceCardFront,
+      insuranceCardBack,
+      gclid: getString(formData, "gclid"),
+      utm_source: getString(formData, "utm_source"),
+      utm_medium: getString(formData, "utm_medium"),
+      utm_campaign: getString(formData, "utm_campaign"),
+      utm_term: getString(formData, "utm_term"),
+      utm_content: getString(formData, "utm_content"),
     });
 
     await sendUserEmail({
       name: fullName,
-      email: body.email,
-      phone: body.phone,
-      state: body.state,
-      reason: body.reason,
-      bestTime: body.bestTime,
-      form_source: 'book-appointment',
-      gclid: body.gclid,
-      utm_source: body.utm_source,
-      utm_medium: body.utm_medium,
-      utm_campaign: body.utm_campaign,
-      utm_term: body.utm_term,
-      utm_content: body.utm_content,
+      email,
+      phone,
+      state,
+      reason,
+      bestTime,
+      form_source: "book-appointment",
+      gclid: getString(formData, "gclid"),
+      utm_source: getString(formData, "utm_source"),
+      utm_medium: getString(formData, "utm_medium"),
+      utm_campaign: getString(formData, "utm_campaign"),
+      utm_term: getString(formData, "utm_term"),
+      utm_content: getString(formData, "utm_content"),
     });
 
     return NextResponse.json({ ok: true });
@@ -108,5 +106,3 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false }, { status: 500 });
   }
 }
-
-

--- a/app/api/forms/doctor/route.ts
+++ b/app/api/forms/doctor/route.ts
@@ -1,57 +1,35 @@
 import { NextResponse } from "next/server";
 import { geolocation } from "@vercel/functions";
-import { Buffer } from "buffer";
 import {
   sendContactEmail,
   sendUserEmail,
 } from "@/components/email/sendcontactemail";
 
-type FilePayload = {
-  name: string;
-  type?: string;
-  base64: string;
-} | null;
+const MAX_UPLOAD_SIZE = 4 * 1024 * 1024;
 
-type DoctorPayload = {
-  firstName: string;
-  lastName: string;
-  email: string;
-  phone: string;
-  reason: string;
-  bestTime: string;
-  postalCode?: string;
-  country?: string;
-  state?: string;
-  insuranceCardFront?: FilePayload;
-  insuranceCardBack?: FilePayload;
-  gclid?: string;
-  utm_source?: string;
-  utm_medium?: string;
-  utm_campaign?: string;
-  utm_term?: string;
-  utm_content?: string;
-};
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
 
-type FileLike = {
-  name: string;
-  arrayBuffer: () => Promise<ArrayBuffer>;
-};
+function getUpload(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return value instanceof File && value.size > 0 ? value : undefined;
+}
 
-function toFileLike(file?: FilePayload): FileLike | undefined {
-  if (!file) {
-    return undefined;
-  }
+function validateUpload(file?: File) {
+  return !file || file.size <= MAX_UPLOAD_SIZE;
+}
 
-  const buffer = Buffer.from(file.base64, "base64");
-  const arrayBuffer = buffer.buffer.slice(
-    buffer.byteOffset,
-    buffer.byteOffset + buffer.byteLength,
+function validateTotalUploads(...files: Array<File | undefined>) {
+  return files.reduce((total, file) => total + (file?.size || 0), 0) <= MAX_UPLOAD_SIZE;
+}
+
+export async function GET() {
+  return NextResponse.json(
+    { ok: false, message: "Method not allowed" },
+    { status: 405, headers: { Allow: "POST" } },
   );
-
-  return {
-    name: file.name,
-    arrayBuffer: async () => arrayBuffer,
-  };
 }
 
 export async function POST(request: Request) {
@@ -65,41 +43,61 @@ export async function POST(request: Request) {
   }
 
   try {
-    const body: DoctorPayload = await request.json();
+    const formData = await request.formData();
+    const insuranceCardFront = getUpload(formData, "insuranceCardFront");
+    const insuranceCardBack = getUpload(formData, "insuranceCardBack");
 
-    const fullName = `${body.firstName} ${body.lastName}`.trim();
+    if (
+      !validateUpload(insuranceCardFront) ||
+      !validateUpload(insuranceCardBack) ||
+      !validateTotalUploads(insuranceCardFront, insuranceCardBack)
+    ) {
+      return NextResponse.json(
+        { ok: false, message: "Uploaded file is too large." },
+        { status: 413 },
+      );
+    }
+
+    const firstName = getString(formData, "firstName");
+    const lastName = getString(formData, "lastName");
+    const email = getString(formData, "email");
+    const phone = getString(formData, "phone");
+    const reason = getString(formData, "reason");
+    const bestTime = getString(formData, "bestTime");
+    const state = getString(formData, "state");
+    const fullName = `${firstName} ${lastName}`.trim();
 
     await sendContactEmail({
       name: fullName,
-      email: body.email,
-      phone: body.phone,
-      reason: body.reason,
-      bestTime: body.bestTime,
-      state: body.state,
-      insuranceCardFront: toFileLike(body.insuranceCardFront) as any,
-      insuranceCardBack: toFileLike(body.insuranceCardBack) as any,
-      gclid: body.gclid,
-      utm_source: body.utm_source,
-      utm_medium: body.utm_medium,
-      utm_campaign: body.utm_campaign,
-      utm_term: body.utm_term,
-      utm_content: body.utm_content,
+      email,
+      phone,
+      reason,
+      bestTime,
+      state,
+      insuranceCardFront,
+      insuranceCardBack,
+      gclid: getString(formData, "gclid"),
+      utm_source: getString(formData, "utm_source"),
+      utm_medium: getString(formData, "utm_medium"),
+      utm_campaign: getString(formData, "utm_campaign"),
+      utm_term: getString(formData, "utm_term"),
+      utm_content: getString(formData, "utm_content"),
     });
 
     await sendUserEmail({
       name: fullName,
-      email: body.email,
-      phone: body.phone,
-      state: body.state,
-      reason: body.reason,
-      bestTime: body.bestTime,
-      form_source: 'doctor-contact',
-      gclid: body.gclid,
-      utm_source: body.utm_source,
-      utm_medium: body.utm_medium,
-      utm_campaign: body.utm_campaign,
-      utm_term: body.utm_term,
-      utm_content: body.utm_content,
+      email,
+      phone,
+      state,
+      reason,
+      bestTime,
+      form_source: "doctor-contact",
+      gclid: getString(formData, "gclid"),
+      utm_source: getString(formData, "utm_source"),
+      utm_medium: getString(formData, "utm_medium"),
+      utm_campaign: getString(formData, "utm_campaign"),
+      utm_term: getString(formData, "utm_term"),
+      utm_content: getString(formData, "utm_content"),
     });
 
     return NextResponse.json({ ok: true });
@@ -108,5 +106,3 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false }, { status: 500 });
   }
 }
-
-

--- a/app/locations/[state]/[location]/page.tsx
+++ b/app/locations/[state]/[location]/page.tsx
@@ -209,6 +209,18 @@ export default async function LocationDetails(
 
                         <SlidingDiv position="left" className="z-[2] sm:hidden block px-4 mt-4">
                             <div className="xl:w-[65%] w-[95%] rounded-3xl mx-auto"><DoctorContactForm backgroundcolor={'rgba(255,255,255,0.00)'} buttonText="Get Your Free Consultation" header="" defaultState={stateInfo?.abbr || state.toUpperCase()} /></div>
+                            <div className="mt-3 xl:w-[65%] w-[95%] mx-auto">
+                                <a
+                                    href={`tel:${statePhone.tel || `+1${statePhone.display.replace(/\D/g, '')}`}`}
+                                    className="flex w-full items-center justify-center gap-2 px-6 py-3 rounded-full bg-white/90 border border-[#0A50EC]/20 shadow-sm text-[#0A50EC] font-bold text-xl"
+                                    style={{ fontFamily: 'var(--font-inter)' }}
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 18 18" fill="none" className="flex-shrink-0">
+                                        <path fillRule="evenodd" clipRule="evenodd" d="M11.3852 0.0666578C11.0536 -0.0290477 10.7071 0.162219 10.6114 0.493864C10.5157 0.825509 10.707 1.17194 11.0386 1.26765C13.78 2.05874 15.9419 4.22057 16.7331 6.96182C16.8288 7.29347 17.1752 7.48472 17.5069 7.389C17.8385 7.29328 18.0298 6.94684 17.9341 6.6152C17.0238 3.46127 14.5392 0.976833 11.3852 0.0666578ZM10.9112 4.11842C10.5935 3.9835 10.2266 4.13169 10.0916 4.4494C9.95671 4.76712 10.1049 5.13406 10.4226 5.26898C11.4596 5.70934 12.2914 6.54113 12.7318 7.57812C12.8667 7.89584 13.2336 8.04402 13.5514 7.9091C13.8691 7.77417 14.0173 7.40724 13.8823 7.08952C13.3154 5.75446 12.2463 4.68536 10.9112 4.11842ZM4.51311 0.906545C4.27945 0.487351 3.90337 0.170069 3.43113 0.0724652C2.95397 -0.0261574 2.47434 0.119319 2.08015 0.440604C0.649844 1.60636 -0.260852 3.47409 0.134395 5.43344C0.377348 6.63783 0.78211 7.82615 1.60638 9.26341C3.2606 12.1479 5.84983 14.7385 8.73763 16.3947C10.1749 17.2189 11.3632 17.6237 12.5676 17.8666C14.5269 18.2619 16.3947 17.3512 17.5604 15.9209C17.8817 15.5267 18.0272 15.0471 17.9286 14.5699C17.831 14.0977 17.5137 13.7216 17.0945 13.4879L15.7591 12.7436C15.2673 12.4694 14.8534 12.2387 14.4936 12.088C14.1119 11.9282 13.7355 11.8332 13.3194 11.8766C12.9032 11.92 12.5545 12.0906 12.2141 12.3257C11.8931 12.5474 11.5357 12.8585 11.111 13.2283L8.97846 15.0848C6.56267 13.611 4.38855 11.4359 2.91618 9.02257L4.77273 6.89005C5.14248 6.46536 5.45365 6.10797 5.67532 5.78698C5.91047 5.44649 6.08101 5.0978 6.12441 4.68166C6.1678 4.26553 6.07287 3.88915 5.91303 3.50747C5.76236 3.14766 5.53163 2.73376 5.25746 2.24192L4.51311 0.906545Z" fill="#0A50EC" />
+                                    </svg>
+                                    {statePhone.display}
+                                </a>
+                            </div>
                         </SlidingDiv>
 
                         <SlidingDiv position="left" className="z-[2]">
@@ -237,16 +249,6 @@ export default async function LocationDetails(
                         {/* Mobile CTA row (under paragraph, above certificates) */}
                         <div className="z-[2] px-4 mt-3 sm:hidden block">
                             <div className="flex flex-col space-y-3 w-full max-w-[480px] mx-auto">
-                                {/* Phone Text Link */}
-                                <div className="w-full flex justify-center">
-                                    <PhoneTextLink
-                                        trackLocation="LocationPageMobile"
-                                        className="justify-center"
-                                        phoneNumber={statePhone.display}
-                                        displayText={statePhone.display}
-                                    />
-                                </div>
-
                                 {/* Get Directions - light grey */}
                                 <Link
                                     href={(locationData.link || (locationData.address ? `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(locationData.address)}` : `https://www.google.com/maps/dir/?api=1&destination=${locationData.lat},${locationData.lng}`))}

--- a/components/BodyPartHeroForm.tsx
+++ b/components/BodyPartHeroForm.tsx
@@ -9,6 +9,7 @@ import { pushFormSubmit } from '@/utils/enhancedConversions';
 import { getAttributionData } from '@/lib/gclid';
 import { formatPhoneInput } from '@/lib/phone-formatter';
 import { STATE_OPTIONS } from '@/lib/stateUtils';
+import { appendPreparedUploads } from '@/lib/client-upload';
 
 interface BodyPartHeroFormProps {
   bodyPartTitle: string;
@@ -92,27 +93,6 @@ export default function BodyPartHeroForm({ bodyPartTitle }: BodyPartHeroFormProp
     setShowDialog(true);
   };
 
-  const toFilePayload = async (file?: File | null) => {
-    if (!file) return null;
-
-    const base64 = await new Promise<string>((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        const result = reader.result?.toString() || '';
-        const [, content] = result.split(',');
-        resolve(content || '');
-      };
-      reader.onerror = (event) => reject(event);
-      reader.readAsDataURL(file);
-    });
-
-    return {
-      name: file.name,
-      type: file.type,
-      base64,
-    };
-  };
-
   const handleFullSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -130,32 +110,46 @@ export default function BodyPartHeroForm({ bodyPartTitle }: BodyPartHeroFormProp
     setError('');
 
     try {
-      const payload = {
-        firstName: formData.firstName,
-        lastName: formData.lastName,
-        email: formData.email,
-        phone: formData.phone,
-        reason: formData.reason || `${bodyPartTitle} pain consultation`,
-        bestTime: formData.bestTime,
-        postalCode: formData.postalCode,
-        state: formData.state,
-        country: 'US',
-        painArea: bodyPartTitle,
-        source: `${bodyPartTitle} Body Part Page`,
-        insuranceCardFront: await toFilePayload(formData.insuranceCardFront),
-        insuranceCardBack: await toFilePayload(formData.insuranceCardBack),
-        gclid: attribution.gclid,
-        utm_source: attribution.utm_source,
-        utm_medium: attribution.utm_medium,
-        utm_campaign: attribution.utm_campaign,
-        utm_term: attribution.utm_term,
-        utm_content: attribution.utm_content,
-      };
+      const payload = new FormData();
+      payload.append('firstName', formData.firstName);
+      payload.append('lastName', formData.lastName);
+      payload.append('email', formData.email);
+      payload.append('phone', formData.phone);
+      payload.append('reason', formData.reason || `${bodyPartTitle} pain consultation`);
+      payload.append('bestTime', formData.bestTime);
+      payload.append('postalCode', formData.postalCode);
+      payload.append('state', formData.state);
+      payload.append('country', 'US');
+      payload.append('painArea', bodyPartTitle);
+      payload.append('source', `${bodyPartTitle} Body Part Page`);
+      payload.append('gclid', attribution.gclid);
+      payload.append('utm_source', attribution.utm_source);
+      payload.append('utm_medium', attribution.utm_medium);
+      payload.append('utm_campaign', attribution.utm_campaign);
+      payload.append('utm_term', attribution.utm_term);
+      payload.append('utm_content', attribution.utm_content);
+
+      const uploadError = await appendPreparedUploads(payload, [
+        { fieldName: 'insuranceCardFront', file: formData.insuranceCardFront },
+        { fieldName: 'insuranceCardBack', file: formData.insuranceCardBack },
+      ]);
+      if (uploadError) {
+        const clearedFields = uploadError.fieldNames.reduce(
+          (nextFormData, fieldName) => ({
+            ...nextFormData,
+            [fieldName]: null,
+          }),
+          formData,
+        );
+
+        setFormData(clearedFields);
+        setError(uploadError.message);
+        return;
+      }
 
       const res = await fetch('/api/forms/doctor', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: payload,
       });
 
       if (res.redirected) {

--- a/components/BookAnAppointmentPopup.tsx
+++ b/components/BookAnAppointmentPopup.tsx
@@ -20,6 +20,7 @@ import BookAnAppointmentClient from "./BookAnAppointmentClient"
 import Link from "next/link"
 import { getAttributionData } from "@/lib/gclid"
 import { useRouter } from "next/navigation"
+import { appendPreparedUploads } from "@/lib/client-upload"
 const formSchema = z.object({
     name: z.string().min(2, "name must be at least 2 characters"),
     email: z.string().email("Invalid email address"),
@@ -58,45 +59,40 @@ export default function BookAnAppointmentPopup() {
         },
     })
 
-
-    async function serializeFile(file: File | null | undefined): Promise<{ name: string; type: string; base64: string } | null> {
-        if (!file) return null;
-        const buffer = await file.arrayBuffer();
-        const bytes = new Uint8Array(buffer);
-        let binary = '';
-        bytes.forEach(b => { binary += String.fromCharCode(b); });
-        return { name: file.name, type: file.type, base64: btoa(binary) };
-    }
-
     async function onSubmit(values: z.infer<typeof formSchema>) {
         try {
             setLoading(true)
 
-            const [insuranceCardFront, insuranceCardBack] = await Promise.all([
-                serializeFile(values.insuranceCardFront),
-                serializeFile(values.insuranceCardBack),
-            ]);
+            const payload = new FormData()
+            payload.append('firstName', values.name.split(' ')[0] || values.name)
+            payload.append('lastName', values.name.split(' ').slice(1).join(' ') || '')
+            payload.append('email', values.email)
+            payload.append('phone', values.phone)
+            payload.append('reason', values.reason)
+            payload.append('bestTime', values.bestTime)
+            payload.append('form_source', 'book-appointment')
+            payload.append('gclid', attribution.gclid)
+            payload.append('utm_source', attribution.utm_source)
+            payload.append('utm_medium', attribution.utm_medium)
+            payload.append('utm_campaign', attribution.utm_campaign)
+            payload.append('utm_term', attribution.utm_term)
+            payload.append('utm_content', attribution.utm_content)
+
+            const uploadError = await appendPreparedUploads(payload, [
+                { fieldName: 'insuranceCardFront', file: values.insuranceCardFront },
+                { fieldName: 'insuranceCardBack', file: values.insuranceCardBack },
+            ])
+            if (uploadError) {
+                uploadError.fieldNames.forEach((fieldName) => {
+                    form.setValue(fieldName as 'insuranceCardFront' | 'insuranceCardBack', null)
+                })
+                form.setError(uploadError.fieldNames[0] as 'insuranceCardFront' | 'insuranceCardBack', { message: uploadError.message })
+                return
+            }
 
             const res = await fetch('/api/forms/book-appointment', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    firstName: values.name.split(' ')[0] || values.name,
-                    lastName: values.name.split(' ').slice(1).join(' ') || '',
-                    email: values.email,
-                    phone: values.phone,
-                    reason: values.reason,
-                    bestTime: values.bestTime,
-                    form_source: 'book-appointment',
-                    insuranceCardFront,
-                    insuranceCardBack,
-                    gclid: attribution.gclid,
-                    utm_source: attribution.utm_source,
-                    utm_medium: attribution.utm_medium,
-                    utm_campaign: attribution.utm_campaign,
-                    utm_term: attribution.utm_term,
-                    utm_content: attribution.utm_content,
-                }),
+                body: payload,
             })
 
             if (res.redirected) {
@@ -298,7 +294,7 @@ export default function BookAnAppointmentPopup() {
                                                         <p className="mb-2 text-sm text-[#111315]">
                                                             <span className="font-semibold">Click to upload</span> or drag and drop
                                                         </p>
-                                                        <p className="text-xs text-[#838890]">PNG, JPG, PDF (MAX. 10MB)</p>
+                                                        <p className="text-xs text-[#838890]">PNG, JPG, PDF up to 15MB</p>
                                                         {value && (
                                                             <p className="text-xs text-green-600 mt-1 font-medium">
                                                                 ✓ {value.name}
@@ -345,7 +341,7 @@ export default function BookAnAppointmentPopup() {
                                                         <p className="mb-2 text-sm text-[#111315]">
                                                             <span className="font-semibold">Click to upload</span> or drag and drop
                                                         </p>
-                                                        <p className="text-xs text-[#838890]">PNG, JPG, PDF (MAX. 10MB)</p>
+                                                        <p className="text-xs text-[#838890]">PNG, JPG, PDF up to 15MB</p>
                                                         {value && (
                                                             <p className="text-xs text-green-600 mt-1 font-medium">
                                                                 ✓ {value.name}
@@ -379,7 +375,6 @@ export default function BookAnAppointmentPopup() {
                             type="submit"
                             disabled={loading}
                             className="w-full self-center flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
-                            onClick={() => setLoading(true)}
                         >
                             {loading ? (
                                 <div className="flex items-center gap-2">

--- a/components/BookAnAppoitmentButton.tsx
+++ b/components/BookAnAppoitmentButton.tsx
@@ -28,6 +28,7 @@ import { STATE_OPTIONS, slugFromPathname, normalizeState } from "@/lib/stateUtil
 import { getAttributionData } from "@/lib/gclid"
 import { ScrollProgress } from "@/components/ui/scroll-progress"
 import { FileUpload } from './ui/file-upload'
+import { appendPreparedUploads } from "@/lib/client-upload"
 const formSchema = z.object({
     firstName: z.string().min(2, "First name must be at least 2 characters"),
     lastName: z.string().min(1, "Last name is required"),
@@ -184,54 +185,40 @@ export default function BookAnAppoitmentButton({
 
     async function onSubmit(values: z.infer<typeof formSchema>) {
         setDisabled(true)
-        const toFilePayload = async (file?: File | null) => {
-            if (!file) {
-                return null
-            }
-
-            const base64 = await new Promise<string>((resolve, reject) => {
-                const reader = new FileReader()
-                reader.onload = () => {
-                    const result = reader.result?.toString() || ""
-                    const [, content] = result.split(",")
-                    resolve(content || "")
-                }
-                reader.onerror = (event) => reject(event)
-                reader.readAsDataURL(file)
-            })
-
-            return {
-                name: file.name,
-                type: file.type,
-                base64,
-            }
-        }
 
         try {
-            const payload = {
-                firstName: values.firstName,
-                lastName: values.lastName,
-                email: values.email,
-                phone: values.phone,
-                reason: values.reason,
-                bestTime: values.bestTime,
-                postalCode: values.postalCode,
-                country: values.country,
-                state: values.state,
-                insuranceCardFront: await toFilePayload(values.insuranceCardFront),
-                insuranceCardBack: await toFilePayload(values.insuranceCardBack),
-                gclid: attribution.gclid,
-                utm_source: attribution.utm_source,
-                utm_medium: attribution.utm_medium,
-                utm_campaign: attribution.utm_campaign,
-                utm_term: attribution.utm_term,
-                utm_content: attribution.utm_content,
+            const payload = new FormData()
+            payload.append("firstName", values.firstName)
+            payload.append("lastName", values.lastName)
+            payload.append("email", values.email)
+            payload.append("phone", values.phone)
+            payload.append("reason", values.reason)
+            payload.append("bestTime", values.bestTime)
+            payload.append("postalCode", values.postalCode)
+            payload.append("country", values.country)
+            payload.append("state", values.state)
+            payload.append("gclid", attribution.gclid)
+            payload.append("utm_source", attribution.utm_source)
+            payload.append("utm_medium", attribution.utm_medium)
+            payload.append("utm_campaign", attribution.utm_campaign)
+            payload.append("utm_term", attribution.utm_term)
+            payload.append("utm_content", attribution.utm_content)
+
+            const uploadError = await appendPreparedUploads(payload, [
+                { fieldName: "insuranceCardFront", file: values.insuranceCardFront },
+                { fieldName: "insuranceCardBack", file: values.insuranceCardBack },
+            ])
+            if (uploadError) {
+                uploadError.fieldNames.forEach((fieldName) => {
+                    form.setValue(fieldName as "insuranceCardFront" | "insuranceCardBack", null)
+                })
+                form.setError(uploadError.fieldNames[0] as "insuranceCardFront" | "insuranceCardBack", { message: uploadError.message })
+                return
             }
 
             const res = await fetch("/api/forms/book-appointment", {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(payload),
+                body: payload,
             })
 
             if (res.redirected) {
@@ -553,7 +540,7 @@ export default function BookAnAppoitmentButton({
                                                                     <p className="mb-2 text-sm text-[#111315]">
                                                                         <span className="font-semibold">Click to upload</span> or drag and drop
                                                                     </p>
-                                                                    <p className="text-xs text-[#838890]">PNG, JPG, PDF (MAX. 10MB)</p>
+                                                                    <p className="text-xs text-[#838890]">PNG, JPG, PDF up to 15MB</p>
                                                                     {value && (
                                                                         <p className="text-xs text-green-600 mt-1 font-medium">
                                                                             ✓ {value.name}
@@ -601,7 +588,7 @@ export default function BookAnAppoitmentButton({
                                                                     <p className="mb-2 text-sm text-[#111315]">
                                                                         <span className="font-semibold">Click to upload</span> or drag and drop
                                                                     </p>
-                                                                    <p className="text-xs text-[#838890]">PNG, JPG, PDF (MAX. 10MB)</p>
+                                                                    <p className="text-xs text-[#838890]">PNG, JPG, PDF up to 15MB</p>
                                                                     {value && (
                                                                         <p className="text-xs text-green-600 mt-1 font-medium">
                                                                             ✓ {value.name}

--- a/components/DoctorContactForm.tsx
+++ b/components/DoctorContactForm.tsx
@@ -317,7 +317,7 @@ export function DoctorContactForm({ backgroundcolor = 'white', header = 'Book an
                                     aria-label="Form section title">
                                     {header}
                                 </p>}
-                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <div className="grid grid-cols-2 gap-3 sm:gap-4">
                                     <FormField
                                         control={form.control}
                                         name="firstName"

--- a/components/DoctorContactForm.tsx
+++ b/components/DoctorContactForm.tsx
@@ -26,6 +26,7 @@ import { STATE_OPTIONS, slugFromPathname, normalizeState } from "@/lib/stateUtil
 import { formatPhone, validatePhoneNumber, formatPhoneInput } from "@/lib/phone-formatter"
 import { useGoogleReCaptcha } from "react-google-recaptcha-v3"
 import { verifyCaptcha } from "@/seo/verify-captcha"
+import { appendPreparedUploads } from "@/lib/client-upload"
 
 const formSchema = z.object({
     firstName: z.string().min(2, "First name must be at least 2 characters"),
@@ -191,54 +192,39 @@ export function DoctorContactForm({ backgroundcolor = 'white', header = 'Book an
 
         setDisabled(true)
 
-        const toFilePayload = async (file?: File | null) => {
-            if (!file) {
-                return null
-            }
-
-            const base64 = await new Promise<string>((resolve, reject) => {
-                const reader = new FileReader()
-                reader.onload = () => {
-                    const result = reader.result?.toString() || ""
-                    const [, content] = result.split(",")
-                    resolve(content || "")
-                }
-                reader.onerror = (event) => reject(event)
-                reader.readAsDataURL(file)
-            })
-
-            return {
-                name: file.name,
-                type: file.type,
-                base64,
-            }
-        }
-
         try {
-            const payload = {
-                firstName: values.firstName,
-                lastName: values.lastName,
-                email: values.email,
-                phone: values.phone,
-                reason: values.reason,
-                bestTime: values.bestTime,
-                postalCode: values.postalCode,
-                country: values.country,
-                state: values.state,
-                insuranceCardFront: await toFilePayload(values.insuranceCardFront),
-                insuranceCardBack: await toFilePayload(values.insuranceCardBack),
-                gclid: attribution.gclid,
-                utm_source: attribution.utm_source,
-                utm_medium: attribution.utm_medium,
-                utm_campaign: attribution.utm_campaign,
-                utm_term: attribution.utm_term,
-                utm_content: attribution.utm_content,
+            const payload = new FormData()
+            payload.append("firstName", values.firstName)
+            payload.append("lastName", values.lastName)
+            payload.append("email", values.email)
+            payload.append("phone", values.phone)
+            payload.append("reason", values.reason)
+            payload.append("bestTime", values.bestTime)
+            payload.append("postalCode", values.postalCode)
+            payload.append("country", values.country)
+            payload.append("state", values.state)
+            payload.append("gclid", attribution.gclid)
+            payload.append("utm_source", attribution.utm_source)
+            payload.append("utm_medium", attribution.utm_medium)
+            payload.append("utm_campaign", attribution.utm_campaign)
+            payload.append("utm_term", attribution.utm_term)
+            payload.append("utm_content", attribution.utm_content)
+
+            const uploadError = await appendPreparedUploads(payload, [
+                { fieldName: "insuranceCardFront", file: values.insuranceCardFront },
+                { fieldName: "insuranceCardBack", file: values.insuranceCardBack },
+            ])
+            if (uploadError) {
+                uploadError.fieldNames.forEach((fieldName) => {
+                    form.setValue(fieldName as "insuranceCardFront" | "insuranceCardBack", null)
+                })
+                form.setError(uploadError.fieldNames[0] as "insuranceCardFront" | "insuranceCardBack", { message: uploadError.message })
+                return
             }
 
             const res = await fetch("/api/forms/doctor", {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(payload),
+                body: payload,
             })
 
             if (res.redirected) {
@@ -911,7 +897,7 @@ export function DoctorContactForm({ backgroundcolor = 'white', header = 'Book an
                                                                                 <p className="mb-2 text-sm text-[#111315]">
                                                                                     <span className="font-semibold">Click to upload</span> or drag and drop
                                                                                 </p>
-                                                                                <p className="text-xs text-[#838890]">PNG, JPG, PDF (MAX. 10MB)</p>
+                                                                                <p className="text-xs text-[#838890]">PNG, JPG, PDF up to 15MB</p>
                                                                                 {value && (
                                                                                     <p className="text-xs text-green-600 mt-1 font-medium">
                                                                                         ✓ {value.name}
@@ -958,7 +944,7 @@ export function DoctorContactForm({ backgroundcolor = 'white', header = 'Book an
                                                                                 <p className="mb-2 text-sm text-[#111315]">
                                                                                     <span className="font-semibold">Click to upload</span> or drag and drop
                                                                                 </p>
-                                                                                <p className="text-xs text-[#838890]">PNG, JPG, PDF (MAX. 10MB)</p>
+                                                                                <p className="text-xs text-[#838890]">PNG, JPG, PDF up to 15MB</p>
                                                                                 {value && (
                                                                                     <p className="text-xs text-green-600 mt-1 font-medium">
                                                                                         ✓ {value.name}

--- a/components/HomeHeroSection.client.tsx
+++ b/components/HomeHeroSection.client.tsx
@@ -30,6 +30,61 @@ import { Clock } from 'lucide-react';
 
 type TimePeriod = 'day' | 'sunset' | 'night';
 
+function HeroPhoneCTA({ timePeriod }: { timePeriod: TimePeriod }) {
+  const isNight = timePeriod === 'night';
+  const defaultPhoneText = '(561) 223-9959';
+  const defaultPhoneHref = 'tel:+15612239959';
+
+  const getDisplayedPhone = () => {
+    if (typeof document === 'undefined') {
+      return defaultPhoneText;
+    }
+    const phoneNode = document.querySelector('[data-callrail-phone="hero-mobile-phone"]');
+    return phoneNode?.textContent?.trim() || defaultPhoneText;
+  };
+
+  return (
+    <div className="w-full mb-3 rounded-2xl border border-white/25 bg-white/10 backdrop-blur-md shadow-[0_8px_30px_rgba(0,0,0,0.18)] px-4 py-3 text-white">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className={`text-xs font-semibold uppercase tracking-wide ${isNight ? 'text-white/80' : 'text-[#EAF1FF]'}`}>
+            Prefer to call?
+          </p>
+          <p className={`text-xs ${isNight ? 'text-white/80' : 'text-[#F3F7FF]'}`}>
+            Tap to speak with our team
+          </p>
+        </div>
+        <a
+          href={defaultPhoneHref}
+          aria-label="Call Mountain Spine and Orthopedics at 561-223-9959"
+          data-cta="hero-phone-call"
+          data-location="homepage-hero"
+          data-phone="+15612239959"
+          className="ctm-phone-number shrink-0 rounded-full bg-white text-[#0A50EC] px-3 py-2 text-sm font-bold shadow-sm hover:bg-white/90 focus:outline-none focus:ring-2 focus:ring-white/70"
+          onClick={() => {
+            const displayPhone = getDisplayedPhone();
+            const cleanPhone = displayPhone.replace(/\D/g, '');
+            if (typeof window !== "undefined" && window.dataLayer) {
+              window.dataLayer.push({
+                event: 'call_click',
+                phone_number: cleanPhone || '5612239959',
+                location: 'HomeHero'
+              });
+            }
+          }}
+        >
+          <span className="inline-flex items-center gap-1.5">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 18 18" fill="none" className="flex-shrink-0">
+              <path fillRule="evenodd" clipRule="evenodd" d="M11.3852 0.0666578C11.0536 -0.0290477 10.7071 0.162219 10.6114 0.493864C10.5157 0.825509 10.707 1.17194 11.0386 1.26765C13.78 2.05874 15.9419 4.22057 16.7331 6.96182C16.8288 7.29347 17.1752 7.48472 17.5069 7.389C17.8385 7.29328 18.0298 6.94684 17.9341 6.6152C17.0238 3.46127 14.5392 0.976833 11.3852 0.0666578ZM10.9112 4.11842C10.5935 3.9835 10.2266 4.13169 10.0916 4.4494C9.95671 4.76712 10.1049 5.13406 10.4226 5.26898C11.4596 5.70934 12.2914 6.54113 12.7318 7.57812C12.8667 7.89584 13.2336 8.04402 13.5514 7.9091C13.8691 7.77417 14.0173 7.40724 13.8823 7.08952C13.3154 5.75446 12.2463 4.68536 10.9112 4.11842ZM4.51311 0.906545C4.27945 0.487351 3.90337 0.170069 3.43113 0.0724652C2.95397 -0.0261574 2.47434 0.119319 2.08015 0.440604C0.649844 1.60636 -0.260852 3.47409 0.134395 5.43344C0.377348 6.63783 0.78211 7.82615 1.60638 9.26341C3.2606 12.1479 5.84983 14.7385 8.73763 16.3947C10.1749 17.2189 11.3632 17.6237 12.5676 17.8666C14.5269 18.2619 16.3947 17.3512 17.5604 15.9209C17.8817 15.5267 18.0272 15.0471 17.9286 14.5699C17.831 14.0977 17.5137 13.7216 17.0945 13.4879L15.7591 12.7436L15.7591 12.7436C15.2673 12.4694 14.8534 12.2387 14.4936 12.088C14.1119 11.9282 13.7355 11.8332 13.3194 11.8766C12.9032 11.92 12.5545 12.0906 12.2141 12.3257C11.8931 12.5474 11.5357 12.8585 11.111 13.2283L8.97846 15.0848C6.56267 13.611 4.38855 11.4359 2.91618 9.02257L4.77273 6.89005C5.14248 6.46536 5.45365 6.10797 5.67532 5.78698C5.91047 5.44649 6.08101 5.0978 6.12441 4.68166C6.1678 4.26553 6.07287 3.88915 5.91303 3.50747C5.76236 3.14766 5.53163 2.73376 5.25746 2.24192L5.25745 2.24191L4.51311 0.906545Z" fill="#0A50EC" />
+            </svg>
+            <span data-callrail-phone="hero-mobile-phone" className="ctm-phone-number">{defaultPhoneText}</span>
+          </span>
+        </a>
+      </div>
+    </div>
+  );
+}
+
 export default function HomeHeroSection() {
   const [hasMounted, setHasMounted] = useState(false);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
@@ -245,6 +300,7 @@ export default function HomeHeroSection() {
             <div className="rounded-2xl">
               <DoctorContactForm backgroundcolor={'#0xFF'} buttonText="Get Your Free Consultation" header="" timePeriod={timePeriod}/>
             </div>
+            <HeroPhoneCTA timePeriod={timePeriod} />
           </div>
           <SlidingDiv position="left" className="z-[2] ">
             <div className="xl:px-[80px] px-8 mb-[24px] xl:w-full md:w-[80%] lg:w-full md:text-left sm:text-center">
@@ -252,7 +308,7 @@ export default function HomeHeroSection() {
                 style={{
                   fontWeight: 400,
                 }}
-                className={`${timePeriod !== 'night' ? 'sm:text-[#424959] text-[#252932]' : 'text-white'} text-xl lg:text-2xl sm:text-left text-center`}
+                className={`${timePeriod !== 'night' ? 'sm:text-[#424959] text-[#252932]' : 'text-white'} text-xl lg:text-2xl sm:text-left text-center hidden sm:block`}
               >
                 Expert orthopedic and spine surgeons offering minimally invasive spine surgery, joint replacement, and advanced back pain treatment across Florida, New Jersey, New York, and Pennsylvania. Same-day and next-day appointments at convenient locations. Book your orthopedic consultation today.
               </p>

--- a/components/HomeInteractiveAnatomy.client.tsx
+++ b/components/HomeInteractiveAnatomy.client.tsx
@@ -155,14 +155,14 @@ export default function HomeInteractiveAnatomy() {
           <div className="flex flex-col space-y-[10px] xl:w-[20%] w-full xl:pt-50 z-20">
             <TextAnimate
               animation="blurInUp"
-              by="character"
+              by="word"
               once
               as="p"
               style={{
                 fontFamily: "var(--font-public-sans)",
                 fontWeight: 500, color: '#0A50EC',
               }}
-              className="xl:text-2xl lg:text-3xl"
+              className="xl:text-2xl lg:text-3xl break-keep"
             >
               {selectedOrthoCondition.area_procedures.title}
             </TextAnimate>

--- a/components/HomeStatisticsBar.client.tsx
+++ b/components/HomeStatisticsBar.client.tsx
@@ -5,21 +5,44 @@ import { NumberTicker } from "@/components/magicui/number-ticker";
 import { Testimonials } from '@/components/data/homepage-data';
 
 export default function HomeStatisticsBar() {
+  const mobileLabelMap: Record<string, string> = {
+    'Successful Treatments': 'Treatments',
+    'Years of Experience': 'Years Experience',
+    'Patient Satasfaction Rate': 'Satisfaction Rate',
+    'Customer Support': 'Support',
+  };
+
   return (
-    <section className="bg-white w-full py-[50px]">
-      <div className="w-full max-w-[1440px] flex flex-col space-y-10 md:space-y-0 md:flex-row mx-auto px-[40px] items-center justify-evenly overflow-hidden">
-        {Testimonials.map((item) => (
-          <div className="flex flex-col space-y-[12px] p-[18px] max-h-[190px] lg:h-[190px] items-center justify-center" key={item.desc}>
-            <strong style={{ fontFamily: "var(--font-public-sans)", fontWeight: 400 }} className="text-black lg:text-6xl md:text-4xl text-6xl">
-              <NumberTicker value={item.value} className="text-black" />
-              {item.stat}
-            </strong>
-            <p style={{ fontFamily: "var(--font-public-sans)", fontWeight: 400 }} className="text-[#424959] text-xl md:text-lg text-center lg:text-start">
-              {item.desc}
-            </p>
-          </div>
-        ))}
+    <section className="bg-white w-full py-6 md:py-[50px]">
+      <div className="w-full max-w-[1440px] mx-auto px-4 md:px-[40px]">
+        <div className="grid grid-cols-2 gap-3 md:hidden">
+          {Testimonials.map((item) => (
+            <div className="rounded-2xl bg-[#F8FAFC] border border-[#E8EEF7] px-3 py-4 text-center shadow-sm" key={item.desc}>
+              <strong style={{ fontFamily: "var(--font-public-sans)", fontWeight: 500 }} className="text-3xl tracking-wide leading-none text-[#111315]">
+                <NumberTicker value={item.value} className="text-[#111315]" />
+                {item.stat}
+              </strong>
+              <p style={{ fontFamily: "var(--font-public-sans)", fontWeight: 400 }} className="mt-2 text-xs leading-snug text-[#424959]">
+                {mobileLabelMap[item.desc] ?? item.desc}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="hidden md:flex w-full flex-col space-y-10 md:space-y-0 md:flex-row items-center justify-evenly overflow-hidden">
+          {Testimonials.map((item) => (
+            <div className="flex flex-col space-y-[12px] p-[18px] max-h-[190px] lg:h-[190px] items-center justify-center" key={item.desc}>
+              <strong style={{ fontFamily: "var(--font-public-sans)", fontWeight: 400 }} className="text-black lg:text-6xl md:text-4xl text-6xl">
+                <NumberTicker value={item.value} className="text-black" />
+                {item.stat}
+              </strong>
+              <p style={{ fontFamily: "var(--font-public-sans)", fontWeight: 400 }} className="text-[#424959] text-xl md:text-lg text-center lg:text-start">
+                {item.desc}
+              </p>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );
-} 
+}

--- a/components/LocationGallerySection.tsx
+++ b/components/LocationGallerySection.tsx
@@ -57,7 +57,7 @@ export default function LocationGallerySection({
         <LocationGallerySlideshow images={clinic.gallery} />
       </div>
 
-      <div className="flex flex-wrap items-center gap-4">
+      <div className="flex flex-wrap items-center justify-center gap-4">
         <Link
           href={directionsUrl}
           target="_blank"

--- a/lib/client-upload.ts
+++ b/lib/client-upload.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import imageCompression from "browser-image-compression";
+
+const MB = 1024 * 1024;
+const ORIGINAL_FILE_LIMIT = 15 * MB;
+const FINAL_FILE_LIMIT = 4 * MB;
+
+const oversizedOriginalMessage =
+  "This file is over 15 MB. Please choose a smaller image or file.";
+const oversizedFinalMessage =
+  "This file is still over 4 MB after compression. Please choose a smaller image.";
+const oversizedCombinedMessage =
+  "The selected uploads are over 4 MB after compression. Please choose smaller images or files.";
+
+function supportsWebP() {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const canvas = document.createElement("canvas");
+  return canvas.toDataURL("image/webp").startsWith("data:image/webp");
+}
+
+function safeCompressedName(file: File) {
+  const baseName = file.name.replace(/\.[^/.]+$/, "");
+  return `${baseName || "upload"}.webp`;
+}
+
+export async function prepareUploadFile(
+  file?: File | null,
+  label = "upload",
+): Promise<{ file: File | null; error?: string }> {
+  if (!file) {
+    return { file: null };
+  }
+
+  if (file.size > ORIGINAL_FILE_LIMIT) {
+    return { file: null, error: oversizedOriginalMessage };
+  }
+
+  let finalFile = file;
+
+  if (file.type.startsWith("image/")) {
+    const compressed = await imageCompression(file, {
+      maxSizeMB: 1.5,
+      maxWidthOrHeight: 1600,
+      useWebWorker: true,
+      initialQuality: 0.75,
+      ...(supportsWebP() ? { fileType: "image/webp" } : {}),
+    });
+
+    finalFile =
+      supportsWebP() && compressed.type === "image/webp"
+        ? new File([compressed], safeCompressedName(file), {
+            type: "image/webp",
+            lastModified: Date.now(),
+          })
+        : compressed;
+
+    if (process.env.NODE_ENV === "development") {
+      console.info("[UploadCompression]", {
+        label,
+        originalSizeMB: Number((file.size / MB).toFixed(2)),
+        compressedSizeMB: Number((finalFile.size / MB).toFixed(2)),
+      });
+    }
+  }
+
+  if (finalFile.size > FINAL_FILE_LIMIT) {
+    return { file: null, error: oversizedFinalMessage };
+  }
+
+  return { file: finalFile };
+}
+
+export async function appendPreparedUploads(
+  formData: FormData,
+  uploads: Array<{ fieldName: string; file?: File | null }>,
+): Promise<{ message: string; fieldNames: string[] } | null> {
+  const preparedUploads: Array<{ fieldName: string; file: File }> = [];
+  let totalSize = 0;
+
+  for (const upload of uploads) {
+    const prepared = await prepareUploadFile(upload.file, upload.fieldName);
+
+    if (prepared.error) {
+      return { message: prepared.error, fieldNames: [upload.fieldName] };
+    }
+
+    if (prepared.file) {
+      totalSize += prepared.file.size;
+      preparedUploads.push({ fieldName: upload.fieldName, file: prepared.file });
+    }
+  }
+
+  if (totalSize > FINAL_FILE_LIMIT) {
+    return {
+      message: oversizedCombinedMessage,
+      fieldNames: preparedUploads.map(({ fieldName }) => fieldName),
+    };
+  }
+
+  preparedUploads.forEach(({ fieldName, file }) => {
+    formData.append(fieldName, file, file.name);
+  });
+
+  return null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@tanstack/react-query": "^5.81.5",
         "@uidotdev/usehooks": "^2.4.1",
         "@vercel/functions": "^3.3.1",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -7354,14 +7355,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.0.38",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.38.tgz",
       "integrity": "sha512-ExsidLLSzYj4cvaQjGnQCk4HFfVT9+EZ9XZsQ8Hsrcn8QNgXtpZ3m9vSIC2MWtx7jHictK6wYhQgGh6ic58oOw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -7373,7 +7374,7 @@
       "version": "18.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
       "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -7383,7 +7384,7 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/statuses": {
@@ -8483,6 +8484,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.24.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
@@ -9115,7 +9125,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/csv-stringify": {
@@ -15679,7 +15689,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15902,6 +15912,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
       "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@tanstack/react-query": "^5.81.5",
     "@uidotdev/usehooks": "^2.4.1",
     "@vercel/functions": "^3.3.1",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
… hero layout

app/locations/[state]/[location]/page.tsx
- Fixed mobile phone CTA button below the contact form: changed from inline-flex/justify-center (content-width only) to flex w-full inside a xl:w-[65%] w-[95%] mx-auto wrapper, matching the form card's width exactly
- Moved phone CTA to sit directly below the form (inside the same SlidingDiv) for better visual grouping on mobile
- Removed the duplicate PhoneTextLink component that previously appeared in the lower mobile CTA row (below the paragraph section)

components/DoctorContactForm.tsx
- Changed First Name / Last Name grid from grid-cols-1 md:grid-cols-2 to grid-cols-2 gap-3 sm:gap-4, so the two name fields always render side-by-side on all screen sizes (matches the screenshot layout)

components/HomeHeroSection.client.tsx
- Added HeroPhoneCTA sub-component: a compact frosted-glass strip rendered below the homepage contact form on mobile, with a tap-to-call button, CallRail DNI-compatible ctm-phone-number class, and a dataLayer call_click event for Google Ads conversion tracking
- Hid the long hero description paragraph on mobile (hidden sm:block) to reduce clutter below the form

components/HomeInteractiveAnatomy.client.tsx
- Changed TextAnimate from by="character" to by="word" and added break-keep to prevent mid-word line breaks in the procedure title animation

components/HomeStatisticsBar.client.tsx
- Added a mobile-only 2-column card grid (grid-cols-2) for the statistics bar with compact labels via mobileLabelMap (e.g. "Successful Treatments" → "Treatments") and rounded card styling
- Desktop layout preserved unchanged under hidden md:flex

components/LocationGallerySection.tsx
- Added justify-center to the CTA button row so buttons center correctly on narrower viewports instead of left-aligning