### PR TITLE
feat(mobile-cro): apply MobileHeroConversionPanel to state location p…

### DIFF
--- a/app/locations/[state]/page.tsx
+++ b/app/locations/[state]/page.tsx
@@ -24,6 +24,7 @@ import { PhoneTextLink } from '@/components/PhoneTextLink'
 import SlidingDiv from '@/components/SlidingAnimation'
 import StateHeroForm from '@/components/StateHeroForm'
 import BarTrans from '@/components/BarTrans'
+import MobileHeroConversionPanel from '@/components/MobileHeroConversionPanel'
 
 export async function generateStaticParams() {
   return VALID_STATE_SLUGS.map((state) => ({ state }))
@@ -254,6 +255,17 @@ export default async function StateHubPage({
                 </h1>
               </SlidingDiv>
 
+              {/* Mobile CRO panel — visible only below sm (640px); desktop uses StateHeroForm on the right */}
+              <div className="w-full sm:hidden mt-4 mb-2">
+                <MobileHeroConversionPanel
+                  pageType="state"
+                  phone={statePhone.display}
+                  phoneTel={`tel:${statePhone.tel}`}
+                  stateName={stateInfo?.name || ''}
+                  defaultState={stateInfo?.abbr || state.toUpperCase()}
+                />
+              </div>
+
               <SlidingDiv position="left">
                 <p style={{ fontFamily: 'var(--font-reem-kufi)', fontWeight: 500 }} className="text-[#252932] text-base sm:text-lg lg:text-xl mb-5 break-words">
                   Board-certified specialists at {stateClinics.length} convenient {stateInfo?.name} location{stateClinics.length > 1 ? 's' : ''}. Same-day and next-day appointments.
@@ -283,8 +295,8 @@ export default async function StateHubPage({
                 </ul>
               </SlidingDiv>
 
-              {/* Phone CTA */}
-              <SlidingDiv position="left">
+              {/* Phone CTA — hidden on mobile where MobileHeroConversionPanel handles this */}
+              <SlidingDiv position="left" className="hidden sm:flex">
                 <PhoneTextLink
                   trackLocation={`StateHero-${stateInfo?.name}`}
                   phoneNumber={statePhone.display}
@@ -294,8 +306,8 @@ export default async function StateHubPage({
               </SlidingDiv>
             </div>
 
-            {/* RIGHT: Hero form card */}
-            <SlidingDiv position="right" className="w-full lg:w-[420px] xl:w-[460px] flex-shrink-0">
+            {/* RIGHT: Hero form card — desktop/tablet only; mobile uses MobileHeroConversionPanel above */}
+            <SlidingDiv position="right" className="w-full lg:w-[420px] xl:w-[460px] flex-shrink-0 hidden sm:block">
               <StateHeroForm defaultState={state} stateName={stateInfo?.name || ''} />
             </SlidingDiv>
 

--- a/components/MobileHeroConversionPanel.tsx
+++ b/components/MobileHeroConversionPanel.tsx
@@ -4,12 +4,13 @@ import React from 'react';
 import MobileHeroMiniForm from '@/components/MobileHeroMiniForm';
 
 interface MobileHeroConversionPanelProps {
-  pageType: 'homepage' | 'location';
+  pageType: 'homepage' | 'location' | 'state';
   phone: string;
   phoneTel: string;
   cityName?: string;
   locationName?: string;
   locationSlug?: string;
+  stateName?: string;
   timePeriod?: string;
   defaultState?: string;
 }
@@ -21,6 +22,7 @@ export default function MobileHeroConversionPanel({
   cityName,
   locationName,
   locationSlug,
+  stateName,
   timePeriod = 'day',
   defaultState = '',
 }: MobileHeroConversionPanelProps) {
@@ -36,6 +38,14 @@ export default function MobileHeroConversionPanel({
           event: 'location_call_click',
           location_name: locationName,
           location_slug: locationSlug,
+          phone_number: phone,
+          page_path: window.location.pathname,
+          cta_position: 'mobile_hero_top_fold',
+        });
+      } else if (pageType === 'state') {
+        window.dataLayer.push({
+          event: 'state_location_call_click',
+          state_name: stateName,
           phone_number: phone,
           page_path: window.location.pathname,
           cta_position: 'mobile_hero_top_fold',
@@ -57,6 +67,7 @@ export default function MobileHeroConversionPanel({
       <MobileHeroMiniForm
         pageType={pageType}
         cityName={cityName}
+        stateName={stateName}
         defaultState={defaultState}
       />
 

--- a/components/MobileHeroMiniForm.tsx
+++ b/components/MobileHeroMiniForm.tsx
@@ -12,12 +12,13 @@ import { STATE_OPTIONS } from '@/lib/stateUtils';
 import { appendPreparedUploads } from '@/lib/client-upload';
 
 interface MobileHeroMiniFormProps {
-  pageType: 'homepage' | 'location';
+  pageType: 'homepage' | 'location' | 'state';
   cityName?: string;
   defaultState?: string;
+  stateName?: string;
 }
 
-export default function MobileHeroMiniForm({ pageType, cityName, defaultState = '' }: MobileHeroMiniFormProps) {
+export default function MobileHeroMiniForm({ pageType, cityName, defaultState = '', stateName }: MobileHeroMiniFormProps) {
   const [formData, setFormData] = useState({
     firstName: '',
     phone: '',
@@ -69,6 +70,8 @@ export default function MobileHeroMiniForm({ pageType, cityName, defaultState = 
 
   const headingText = pageType === 'location' && cityName
     ? `Orthopedic Care in ${cityName}?`
+    : pageType === 'state' && stateName
+    ? `Need Care in ${stateName}?`
     : 'Experiencing Pain?';
 
   const handleInitialSubmit = (e: React.FormEvent) => {
@@ -81,6 +84,14 @@ export default function MobileHeroMiniForm({ pageType, cityName, defaultState = 
     if (formData.phone.replace(/\D/g, '').length < 10) {
       setError('Please enter a valid phone number');
       return;
+    }
+    if (typeof window !== 'undefined' && window.dataLayer && pageType === 'state') {
+      window.dataLayer.push({
+        event: 'state_location_form_open',
+        state_name: stateName,
+        page_path: window.location.pathname,
+        cta_position: 'mobile_hero_top_fold',
+      });
     }
     setShowDialog(true);
   };
@@ -105,7 +116,11 @@ export default function MobileHeroMiniForm({ pageType, cityName, defaultState = 
       payload.append('postalCode', formData.postalCode);
       payload.append('state', formData.state);
       payload.append('country', 'US');
-      payload.append('source', pageType === 'location' ? `Location Hero - ${cityName || ''}` : 'Homepage Hero');
+      payload.append('source',
+        pageType === 'location' ? `Location Hero - ${cityName || ''}` :
+        pageType === 'state' ? `State Hero - ${stateName || ''}` :
+        'Homepage Hero'
+      );
       payload.append('gclid', attribution.gclid);
       payload.append('utm_source', attribution.utm_source);
       payload.append('utm_medium', attribution.utm_medium);


### PR DESCRIPTION
…ages

Extends the mobile CRO conversion panel (already live on homepage + clinic pages) to all state-level /locations/[state] routes (FL, NJ, NY, PA).

Changes:
- MobileHeroConversionPanel: adds 'state' pageType, stateName prop, and state_location_call_click dataLayer event
- MobileHeroMiniForm: adds 'state' pageType, stateName prop, state-aware headingText ("Need Care in Florida?"), source field, and state_location_form_open dataLayer event on dialog open
- [state]/page.tsx: injects MobileHeroConversionPanel below H1 (sm:hidden), hides StateHeroForm on mobile (hidden sm:block), hides PhoneTextLink on mobile (hidden sm:flex) to eliminate redundancy

Mobile result: H1 → compact form card + call button above the fold. Desktop result: unchanged — StateHeroForm still renders in the right column. All SEO metadata, schema, H1s, and canonicals are untouched.